### PR TITLE
Updating version of google-spreadsheet reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "debug": "^2.1.3",
     "event-stream": "^3.3.0",
-    "google-spreadsheet": "^0.2.8",
+    "google-spreadsheet": "^2.0.4",
     "vinyl": "^0.4.6"
   },
   "devDependencies": {


### PR DESCRIPTION
As discussed in issue #1 - the version of google-spreadsheet referenced by the project is outdated and breaking all functionality.

Have switched to the latest version which appears to get things moving again but have not done a full regression test of the plugin.